### PR TITLE
Fix - Update the DockerFile Ubuntu Image Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.14
+apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
   | tar -C / --overwrite -xvzf -
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Brief
This problem was raised by the students of the africa masterclass: 
![image](https://github.com/Mugen-Builders/calculator/assets/153661799/9c63577b-bfbb-4da3-a1f8-6c6f925824fc)

This happens due to the fact sunodo version in the time calculator was done was different. This PR fixes this problem.

## Activities

Fix: changes line 10 from curl=7.81.0-1ubuntu1.14 to curl=7.81.0-1ubuntu1.15


## Evidences

![image](https://github.com/Mugen-Builders/calculator/assets/153661799/2e77ec2f-0d4a-4704-a9d1-c9704f7c57b6)
